### PR TITLE
Collaborative Filtering baseline code

### DIFF
--- a/bomin/3_1. collaborative filering_KNNBasic.ipynb
+++ b/bomin/3_1. collaborative filering_KNNBasic.ipynb
@@ -1,0 +1,1391 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip3 install surprise # 처음 한번만 인스톨"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings = pd.read_csv(\"./data/ml-latest-small/ratings.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings = ratings.drop('timestamp', axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 서프라이즈 패키지용 데이터셋 세팅"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise import Reader, Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 서프라이즈 패키지에게 rating의 최솟값, 최댓값 알려줌\n",
+    "reader = Reader(rating_scale=(0,5))\n",
+    "data = Dataset.load_from_df(ratings, reader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## train, test 데이터 셋 세팅"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r_train, r_test = train_test_split(data, test_size=0.1, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "# KNNBasic 모델링 user-user"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 영화 하나만 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise import KNNBasic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# knn basic 모델 셋팅\n",
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNBasic(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc45676d7b8>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(325, 3863, 3.0),\n",
+       " (1, 6, 4.0),\n",
+       " (104, 4676, 3.0),\n",
+       " (441, 4402, 5.0),\n",
+       " (474, 2211, 3.0),\n",
+       " (298, 8814, 0.5),\n",
+       " (63, 115617, 5.0),\n",
+       " (448, 380, 3.0),\n",
+       " (182, 2022, 5.0),\n",
+       " (68, 46970, 3.0)]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test 데이터 실제값 확인 (user_id, item_id, rating)\n",
+    "r_test[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(104, 4676, 3.0)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한 개 뽑아오기 (user_id, item_id, rating)\n",
+    "tr_only = r_test[2]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=104, iid=4676, r_ui=None, est=1.6820061369915678, details={'actual_k': 5, 'was_impossible': False})"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.6820061369915678"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "예측값 결과 설명\n",
+    "- uid : user_id\n",
+    "- iid : item_id\n",
+    "- r_ui : rating(실제값)\n",
+    "- est : 모델이 예측한 값\n",
+    "- actual_k : 지정해준 최소 최대값 사이에서 실제로 이 예측을 하기 위해 사용된 neighbor의 숫자, was_impossible이 True이면 이 정보는 나타나지 않음\n",
+    "- was_impossible : 지정해준 조건 내에서 예측이 가능했는지 불가능했는지 기록된 지표 True일 경우 조건내에서 예측값을 가져오는 것이 불가능했다는 표시\n",
+    "    - reason : 왜 조건 내에서 예측이 불가능했는지 이유를 알려주는 항목"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(325, 3863, 3.0)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# was_impossible = True인 경우\n",
+    "tr_only = r_test[0]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=325, iid=3863, r_ui=None, est=3.1999817408586377, details={'actual_k': 10, 'was_impossible': False})"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "was_impossible = True일 경우 ratings의 glabal_mean으로 예측."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.1999817408586377"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r_train.global_mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### r_test 리스트에 있는 영화 모두 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNBasic(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc456767470>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prediction(uid=325, iid=3863, r_ui=3.0, est=3.1999817408586377, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=1, iid=6, r_ui=4.0, est=4.350761044575351, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=104, iid=4676, r_ui=3.0, est=1.6820061369915678, details={'actual_k': 5, 'was_impossible': False}),\n",
+       " Prediction(uid=441, iid=4402, r_ui=5.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=474, iid=2211, r_ui=3.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=298, iid=8814, r_ui=0.5, est=2.232020032421871, details={'actual_k': 6, 'was_impossible': False}),\n",
+       " Prediction(uid=63, iid=115617, r_ui=5.0, est=4.1513356395820376, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=448, iid=380, r_ui=3.0, est=3.550925566266186, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=182, iid=2022, r_ui=5.0, est=3.498397373400408, details={'actual_k': 7, 'was_impossible': False}),\n",
+       " Prediction(uid=68, iid=46970, r_ui=3.0, est=3.6017090914185066, details={'actual_k': 10, 'was_impossible': False})]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = model.test(r_test)\n",
+    "predictions[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9854\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9854225599381397"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KNNBasic 모델링 user-user(파라미터 튜닝)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNBasic(k=40, min_k=5, sim_options=sim_options, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc453eb57f0>"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid='15', iid='4018', r_ui=None, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'})"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 예측값\n",
+    "uid = str(15)\n",
+    "iid = str(4018)\n",
+    "model.predict(uid, iid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = model.test(r_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9762\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9761751339369014"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "# KNNBasic 모델링 item-item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 영화 하나만 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# knn basic 모델 셋팅\n",
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNBasic(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc4567673c8>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(325, 3863, 3.0),\n",
+       " (1, 6, 4.0),\n",
+       " (104, 4676, 3.0),\n",
+       " (441, 4402, 5.0),\n",
+       " (474, 2211, 3.0),\n",
+       " (298, 8814, 0.5),\n",
+       " (63, 115617, 5.0),\n",
+       " (448, 380, 3.0),\n",
+       " (182, 2022, 5.0),\n",
+       " (68, 46970, 3.0)]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test 데이터 실제값 확인 (user_id, item_id, rating)\n",
+    "r_test[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(325, 3863, 3.0)"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한 개 뽑아오기 (user_id, item_id, rating)\n",
+    "tr_only = r_test[0]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=325, iid=3863, r_ui=None, est=3.8, details={'actual_k': 10, 'was_impossible': False})"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.8"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "예측값 결과 설명\n",
+    "- uid : user_id\n",
+    "- iid : item_id\n",
+    "- r_ui : rating(실제값)\n",
+    "- est : 모델이 예측한 값\n",
+    "- actual_k : 지정해준 최소 최대값 사이에서 실제로 이 예측을 하기 위해 사용된 neighbor의 숫자, was_impossible이 True이면 이 정보는 나타나지 않음\n",
+    "- was_impossible : 지정해준 조건 내에서 예측이 가능했는지 불가능했는지 기록된 지표 True일 경우 조건내에서 예측값을 가져오는 것이 불가능했다는 표시\n",
+    "    - reason : 왜 조건 내에서 예측이 불가능했는지 이유를 알려주는 항목"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(441, 4402, 5.0)"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# was_impossible = True인 경우\n",
+    "tr_only = r_test[3]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=441, iid=4402, r_ui=None, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'})"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "was_impossible = True일 경우 ratings의 glabal_mean으로 예측."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r_train.global_mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### r_test 리스트에 있는 영화 모두 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNBasic(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc4562c8dd8>"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prediction(uid=325, iid=3863, r_ui=3.0, est=3.8, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=1, iid=6, r_ui=4.0, est=4.400382986188536, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=104, iid=4676, r_ui=3.0, est=3.9, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=441, iid=4402, r_ui=5.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=474, iid=2211, r_ui=3.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=298, iid=8814, r_ui=0.5, est=2.15, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=63, iid=115617, r_ui=5.0, est=4.05, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=448, iid=380, r_ui=3.0, est=2.25, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=182, iid=2022, r_ui=5.0, est=3.55, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=68, iid=46970, r_ui=3.0, est=3.2, details={'actual_k': 10, 'was_impossible': False})]"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = model.test(r_test)\n",
+    "predictions[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 1.0273\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1.0272846143656624"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KNNBasic 모델링 item-item(파라미터 튜닝)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNBasic(k=60, min_k=10, sim_options=sim_options, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNBasic at 0x7fc453469208>"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9762\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9761751339369014"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 그리드서치로 최적 파라미터 확인(기획 확인용)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.model_selection import GridSearchCV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {\n",
+    "    \"name\" : [\"cosine\"]\n",
+    "    , \"min_support\" : [1]\n",
+    "    , \"user_based\" : [False]\n",
+    "}\n",
+    "param_grid = {\"k\":[10,20,30,40,50,60] , \"min_k\":[1,5,10,15,20,25,30], \"sim_options\": sim_options}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gs = GridSearchCV(KNNBasic, param_grid, measures=[\"rmse\"], n_jobs=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gs.fit(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9684420464376252"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gs.best_score[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 60,\n",
+       " 'min_k': 10,\n",
+       " 'sim_options': {'name': 'cosine', 'min_support': 1, 'user_based': False}}"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gs.best_params[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/bomin/3_2. collaborative filtering_KnnWithMeans.ipynb
+++ b/bomin/3_2. collaborative filtering_KnnWithMeans.ipynb
@@ -1,0 +1,1609 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip3 install surprise # 처음 한번만 인스톨"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings = pd.read_csv(\"./data/ml-latest-small/ratings.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratings = ratings.drop('timestamp', axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 서프라이즈 패키지용 데이터셋 세팅"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise import Reader, Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 서프라이즈 패키지에게 rating의 최솟값, 최댓값 알려줌\n",
+    "reader = Reader(rating_scale=(0,5))\n",
+    "data = Dataset.load_from_df(ratings, reader)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## train, test 데이터 셋 세팅"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r_train, r_test = train_test_split(data, test_size=0.1, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "# KNNWithMeans user-user 모델링"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 영화 하나만 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.prediction_algorithms.knns import KNNWithMeans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# knn with means 모델 셋팅\n",
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNWithMeans(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the pearson similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff4198c46d8>"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(325, 3863, 3.0),\n",
+       " (1, 6, 4.0),\n",
+       " (104, 4676, 3.0),\n",
+       " (441, 4402, 5.0),\n",
+       " (474, 2211, 3.0),\n",
+       " (298, 8814, 0.5),\n",
+       " (63, 115617, 5.0),\n",
+       " (448, 380, 3.0),\n",
+       " (182, 2022, 5.0),\n",
+       " (68, 46970, 3.0)]"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test 데이터 실제값 확인 (user_id, item_id, rating)\n",
+    "r_test[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(104, 4676, 3.0)"
+      ]
+     },
+     "execution_count": 115,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한 개 뽑아오기 (user_id, item_id, rating)\n",
+    "tr_only = r_test[2]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=104, iid=4676, r_ui=None, est=1.001341310697164, details={'actual_k': 3, 'was_impossible': False})"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.001341310697164"
+      ]
+     },
+     "execution_count": 118,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "예측값 결과 설명\n",
+    "- uid : user_id\n",
+    "- iid : item_id\n",
+    "- r_ui : rating(실제값)\n",
+    "- est : 모델이 예측한 값\n",
+    "- actual_k : 지정해준 최소 최대값 사이에서 실제로 이 예측을 하기 위해 사용된 neighbor의 숫자, was_impossible이 True이면 이 정보는 나타나지 않음\n",
+    "- was_impossible : 지정해준 조건 내에서 예측이 가능했는지 불가능했는지 기록된 지표 True일 경우 조건내에서 예측값을 가져오는 것이 불가능했다는 표시\n",
+    "    - reason : 왜 조건 내에서 예측이 불가능했는지 이유를 알려주는 항목"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(441, 4402, 5.0)"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# was_impossible = True인 경우\n",
+    "tr_only = r_test[3]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 126,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=441, iid=4402, r_ui=None, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'})"
+      ]
+     },
+     "execution_count": 126,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "was_impossible = True일 경우 ratings의 glabal_mean으로 예측."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 127,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 128,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r_train.global_mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### r_test 리스트에 있는 영화 모두 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNWithMeans(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the cosine similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff4198c43c8>"
+      ]
+     },
+     "execution_count": 149,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prediction(uid=325, iid=3863, r_ui=3.0, est=2.7556253072397214, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=1, iid=6, r_ui=4.0, est=4.745895832673508, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=104, iid=4676, r_ui=3.0, est=2.028000598730642, details={'actual_k': 5, 'was_impossible': False}),\n",
+       " Prediction(uid=441, iid=4402, r_ui=5.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=474, iid=2211, r_ui=3.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=298, iid=8814, r_ui=0.5, est=1.393273476384284, details={'actual_k': 6, 'was_impossible': False}),\n",
+       " Prediction(uid=63, iid=115617, r_ui=5.0, est=3.738577114356836, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=448, iid=380, r_ui=3.0, est=2.6432329747530563, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=182, iid=2022, r_ui=5.0, est=3.4289288563288944, details={'actual_k': 7, 'was_impossible': False}),\n",
+       " Prediction(uid=68, iid=46970, r_ui=3.0, est=3.0672284056211274, details={'actual_k': 10, 'was_impossible': False})]"
+      ]
+     },
+     "execution_count": 150,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = model.test(r_test)\n",
+    "predictions[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9110\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9109803318153976"
+      ]
+     },
+     "execution_count": 152,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KNNWithMeans 모델링 user-user(파라미터 튜닝)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'cosine',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': True}\n",
+    "\n",
+    "model = KNNWithMeans(k=40, min_k=5, sim_options=sim_options, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the pearson similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff4198c4438>"
+      ]
+     },
+     "execution_count": 145,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9038\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9038129621238673"
+      ]
+     },
+     "execution_count": 147,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br>\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "# KNNWithMeans item-item 모델링"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 영화 하나만 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.prediction_algorithms.knns import KNNWithMeans"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# knn with means 모델 셋팅\n",
+    "sim_options = {'name': 'pearson',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNWithMeans(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the pearson similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff4198c4c50>"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 156,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(325, 3863, 3.0),\n",
+       " (1, 6, 4.0),\n",
+       " (104, 4676, 3.0),\n",
+       " (441, 4402, 5.0),\n",
+       " (474, 2211, 3.0),\n",
+       " (298, 8814, 0.5),\n",
+       " (63, 115617, 5.0),\n",
+       " (448, 380, 3.0),\n",
+       " (182, 2022, 5.0),\n",
+       " (68, 46970, 3.0)]"
+      ]
+     },
+     "execution_count": 156,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test 데이터 실제값 확인 (user_id, item_id, rating)\n",
+    "r_test[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(104, 4676, 3.0)"
+      ]
+     },
+     "execution_count": 157,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한 개 뽑아오기 (user_id, item_id, rating)\n",
+    "tr_only = r_test[2]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=104, iid=4676, r_ui=None, est=1.7364434288730592, details={'actual_k': 10, 'was_impossible': False})"
+      ]
+     },
+     "execution_count": 158,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 159,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.7364434288730592"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "예측값 결과 설명\n",
+    "- uid : user_id\n",
+    "- iid : item_id\n",
+    "- r_ui : rating(실제값)\n",
+    "- est : 모델이 예측한 값\n",
+    "- actual_k : 지정해준 최소 최대값 사이에서 실제로 이 예측을 하기 위해 사용된 neighbor의 숫자, was_impossible이 True이면 이 정보는 나타나지 않음\n",
+    "- was_impossible : 지정해준 조건 내에서 예측이 가능했는지 불가능했는지 기록된 지표 True일 경우 조건내에서 예측값을 가져오는 것이 불가능했다는 표시\n",
+    "    - reason : 왜 조건 내에서 예측이 불가능했는지 이유를 알려주는 항목"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(441, 4402, 5.0)"
+      ]
+     },
+     "execution_count": 160,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# was_impossible = True인 경우\n",
+    "tr_only = r_test[3]\n",
+    "tr_only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Prediction(uid=441, iid=4402, r_ui=None, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'})"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# 데이터 한개에 대한 모델의 예측값\n",
+    "uid = tr_only[0]\n",
+    "iid = tr_only[1]\n",
+    "\n",
+    "tr_only_pred = model.predict(uid, iid) # 예측결과 전체 다 가져오기\n",
+    "tr_only_pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "was_impossible = True일 경우 ratings의 glabal_mean으로 예측."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 162,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 162,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tr_only_pred.est # 예측 '값'만 가져오기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.5026225317348376"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r_train.global_mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### r_test 리스트에 있는 영화 모두 예측해보기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'pearson',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNWithMeans(k=10, min_k=3, sim_options=sim_options)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the pearson similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff4196d6e10>"
+      ]
+     },
+     "execution_count": 165,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Prediction(uid=325, iid=3863, r_ui=3.0, est=3.2585027100271002, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=1, iid=6, r_ui=4.0, est=4.611180648089032, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=104, iid=4676, r_ui=3.0, est=1.7364434288730592, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=441, iid=4402, r_ui=5.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=474, iid=2211, r_ui=3.0, est=3.5026225317348376, details={'was_impossible': True, 'reason': 'User and/or item is unkown.'}),\n",
+       " Prediction(uid=298, iid=8814, r_ui=0.5, est=1.0827618349392543, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=63, iid=115617, r_ui=5.0, est=3.8741222791956886, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=448, iid=380, r_ui=3.0, est=3.2599857549857547, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=182, iid=2022, r_ui=5.0, est=4.0979402124160185, details={'actual_k': 10, 'was_impossible': False}),\n",
+       " Prediction(uid=68, iid=46970, r_ui=3.0, est=3.109577922077922, details={'actual_k': 10, 'was_impossible': False})]"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = model.test(r_test)\n",
+    "predictions[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9314\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9314269490018052"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## KNNWithMeans 모델링 user-user(파라미터 튜닝)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "모델에 사용되는 파라미터 설명\n",
+    "- k : 비슷한 유저들 중에서 최대 몇 명까지의 점수를 참고할지 최대값 (기본 40)\n",
+    "- min_k : 비슷한 유저들이 별로 없을 경우 최소로 매칭될 k의 갯수 (기본 1)\n",
+    "- sim_options : 유사도 옵션\n",
+    "    - name : 사용할 유사도 종류('SVD', 'cosine', 'pearson', 'pearson-baseline' / 기본 'SVD')\n",
+    "    - min_support : 유사한 아이템 갯수가 충분하지 않을 경우 최소로 사용할 수 있는 갯수 (기본 1)\n",
+    "    - user_based : user 기반 추천인지 item 기반 추천인지(True:user-user, False:item-item / 기본 True)\n",
+    "    - sgrinkage : pearson_baseline 유사도를 구할때 옵션으로 사용하는 파라미터.\n",
+    "- verbose : 내부 프로세싱 출력"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 200,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {'name': 'pearson',\n",
+    "              'min_support': 1,\n",
+    "              'user_based': False}\n",
+    "\n",
+    "model = KNNWithMeans(k=60, min_k=10, sim_options=sim_options, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the pearson similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<surprise.prediction_algorithms.knns.KNNWithMeans at 0x7ff41968f908>"
+      ]
+     },
+     "execution_count": 201,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(r_train)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RMSE 확인해보기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 202,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.accuracy import rmse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE: 0.9314\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9314269490018052"
+      ]
+     },
+     "execution_count": 203,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rmse(predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 그리드서치로 최적 파라미터 확인(기획 확인용)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from surprise.model_selection import GridSearchCV, RandomizedSearchCV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_options = {\n",
+    "    \"name\" : [\"cosine\"]\n",
+    "    , \"min_support\" : [1]\n",
+    "    , \"user_based\" : [True]\n",
+    "}\n",
+    "param_grid = {\"k\":[10,30,50] , \"min_k\":[1,5,15,25,30], \"sim_options\": sim_options}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gs = GridSearchCV(KNNWithMeans, param_grid, measures=[\"rmse\"], n_jobs=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-142-47a605721ed8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mgs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/.local/lib/python3.6/site-packages/surprise/model_selection/search.py\u001b[0m in \u001b[0;36mfit\u001b[0;34m(self, data)\u001b[0m\n\u001b[1;32m     88\u001b[0m         out = Parallel(n_jobs=self.n_jobs,\n\u001b[1;32m     89\u001b[0m                        \u001b[0mpre_dispatch\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpre_dispatch\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 90\u001b[0;31m                        verbose=self.joblib_verbose)(delayed_list)\n\u001b[0m\u001b[1;32m     91\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m         (test_measures_dicts,\n",
+      "\u001b[0;32m~/.local/lib/python3.6/site-packages/joblib/parallel.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, iterable)\u001b[0m\n\u001b[1;32m   1014\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1015\u001b[0m             \u001b[0;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_backend\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mretrieval_context\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1016\u001b[0;31m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mretrieve\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1017\u001b[0m             \u001b[0;31m# Make sure that we get a last message telling us we are done\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1018\u001b[0m             \u001b[0melapsed_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m-\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_start_time\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/.local/lib/python3.6/site-packages/joblib/parallel.py\u001b[0m in \u001b[0;36mretrieve\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    906\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    907\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_backend\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'supports_timeout'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 908\u001b[0;31m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_output\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjob\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    909\u001b[0m                 \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    910\u001b[0m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_output\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mextend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mjob\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/.local/lib/python3.6/site-packages/joblib/_parallel_backends.py\u001b[0m in \u001b[0;36mwrap_future_result\u001b[0;34m(future, timeout)\u001b[0m\n\u001b[1;32m    552\u001b[0m         AsyncResults.get from multiprocessing.\"\"\"\n\u001b[1;32m    553\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 554\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfuture\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    555\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mLokyTimeoutError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    556\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mTimeoutError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/lib/python3.6/concurrent/futures/_base.py\u001b[0m in \u001b[0;36mresult\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    425\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__get_result\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    426\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 427\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_condition\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwait\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    428\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    429\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_state\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mCANCELLED\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mCANCELLED_AND_NOTIFIED\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/lib/python3.6/threading.py\u001b[0m in \u001b[0;36mwait\u001b[0;34m(self, timeout)\u001b[0m\n\u001b[1;32m    293\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m    \u001b[0;31m# restore state no matter what (e.g., KeyboardInterrupt)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    294\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mtimeout\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 295\u001b[0;31m                 \u001b[0mwaiter\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0macquire\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    296\u001b[0m                 \u001b[0mgotit\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    297\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "gs.fit(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gs.best_score[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gs.best_params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "gs.best_params[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "랜덤서치로 최적 파라미터 확인"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import uniform"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create regularization penalty space\n",
+    "penalty = ['l1', 'l2']\n",
+    "\n",
+    "# Create regularization hyperparameter distribution using uniform distribution\n",
+    "C = uniform(loc=0, scale=4)\n",
+    "\n",
+    "# Create hyperparameter options\n",
+    "hyperparameters = dict(C=C, penalty=penalty)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rs = RandomizedSearchCV(KNNWithMeans, hyperparameters, n_iter=10, measures=[u'rmse'], cv=3, refit=False, return_train_measures=False, n_jobs=1, pre_dispatch=u'2*n_jobs', random_state=42, joblib_verbose=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n",
+      "Computing the msd similarity matrix...\n",
+      "Done computing similarity matrix.\n"
+     ]
+    }
+   ],
+   "source": [
+    "rs.fit(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.9051967113819902"
+      ]
+     },
+     "execution_count": 107,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rs.best_score[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'rmse': {'C': 1.49816047538945, 'penalty': 'l1'}}"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rs.best_params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'C': 1.49816047538945, 'penalty': 'l1'}"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rs.best_params[\"rmse\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "refit is False, cannot use predict()",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-111-ea2fd2bc2357>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mrs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mr_test\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/.local/lib/python3.6/site-packages/surprise/model_selection/search.py\u001b[0m in \u001b[0;36mpredict\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m    201\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    202\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrefit\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 203\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'refit is False, cannot use predict()'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    204\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    205\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbest_estimator\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrefit\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: refit is False, cannot use predict()"
+     ]
+    }
+   ],
+   "source": [
+    "rs.predict(r_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
1. KNNBasic
- user-user CF 구현(cosine 유사도)
- item-item CF 구현(cosine 유사도)

2. KNNWithMeans
- user-user(cosine 유사도)
- item-item(pearson 유사도)

각 단계별로 유저 1명 뽑아서 보기 -> test 셋에 적용해보기 로 넘어가는 방식이 반복해서 들어있습니다. 
KNNBasic에서는 user-user / item-item 작동 기본 방식과 유사도 기본적인 유사도 계산(cosine)을 학습하고, KNNWithMeans에서 또다른 유사도 개념을 넣는 게 좋을 것 같아서 pearson을 가장 뒤로 빼두었습니다. 

- [ ] 유저별로 1명씩 뽑아서 예측 돌려보는 건 한 번만 해도 될지

- [ ] 코드 그대로 갈지

- [ ] 어떻게 단계적으로 개념들을 알려줄지

논의가 필요할 것 같아요. 이야기를 나눠보면 좋을 듯 합니다.

+ 애저 노트북에서 item-item CF가 안돌아가는 엄청나게 커다란 이슈가 있습니다.. 
10번정도 돌려봤는데 노트북 커널이 매번 꺼지는 현상을 목격하였고, 로컬로 이동하여 item-item CF 돌리는 데에 user-user보다 배로 연산 시간이 많이 드는 것을 보니 연산량이 커지면 애저 노트북 내부에서 커널을 끊어버리는 지도 모르겠습니다.. 
혹시 시간 되시는 분 item-item CF 코드로 확인 부탁드려요!